### PR TITLE
Eliminate the freelist from the buffer manager and depend on clocksweep.

### DIFF
--- a/src/backend/storage/buffer/buf_init.c
+++ b/src/backend/storage/buffer/buf_init.c
@@ -128,20 +128,11 @@ BufferManagerShmemInit(void)
 
 			pgaio_wref_clear(&buf->io_wref);
 
-			/*
-			 * Initially link all the buffers together as unused. Subsequent
-			 * management of this list is done by freelist.c.
-			 */
-			buf->freeNext = i + 1;
-
 			LWLockInitialize(BufferDescriptorGetContentLock(buf),
 							 LWTRANCHE_BUFFER_CONTENT);
 
 			ConditionVariableInit(BufferDescriptorGetIOCV(buf));
 		}
-
-		/* Correct last entry of linked list */
-		GetBufferDescriptor(NBuffers - 1)->freeNext = FREENEXT_END_OF_LIST;
 	}
 
 	/* Init other shared buffer-management stuff */


### PR DESCRIPTION
This set of changes removes the list of available buffers and instead simply uses the clocksweep algorithm to find and return an available buffer.  While on the surface this appears to be removing an optimization it is in fact eliminating code that induces overhead in the form of synchronization that is problemmatic for multi-core systems.  This change removes the have_free_buffer() function that was used in the pg_prewarm module.