### PR TITLE
Test PRMX integration

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -3,3 +3,5 @@ https://www.postgresql.org/docs/current/release.html
 
 Distribution file sets include release notes for their version and preceding
 versions.  Visit the file doc/src/sgml/html/release.html in an HTML browser.
+
+and that's the way it was... walter cronkite

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ about building PostgreSQL from the source code can be found at
 The latest version of this software, and related software, may be
 obtained at <https://www.postgresql.org/download/>.  For more information
 look at our web site located at <https://www.postgresql.org/>.
+
+test. test.
+test...ing...the test.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ look at our web site located at <https://www.postgresql.org/>.
 
 test. test.
 test...ing...the test.
+test v4


### PR DESCRIPTION
Testing PRMX email bridge functionality

For readability. It was a slight modularity violation to have fields
in PGShmemHeader that were only used by the allocator code in
shmem.c. And it was inconsistent that ShmemLock was nevertheless not
stored there. Moving all the allocator-related fields to a separate
struct makes it more consistent and modular, and removes the need to
allocate and pass ShmemLock separately via BackendParameters.

Merge InitShmemAccess() and InitShmemAllocation() into a single
function that initializes the struct when called from postmaster, and
when called from backends in EXEC_BACKEND mode, re-establishes the
global variables. That's similar to all the *ShmemInit() functions
that we have.