### PR TITLE
pg_fts: three small cleanups (analyzer alloc, ftsdoc_out escaping, include order)

### DIFF
--- a/contrib/pg_fts/pg_fts_analyze.c
+++ b/contrib/pg_fts/pg_fts_analyze.c
@@ -95,19 +95,27 @@ fts_analyze_text(const char *str, int len)
 	int			maxraw;
 	int			i;
 	uint32		doclen = 0;
+	char	   *foldbuf;
 
 	/* Upper bound on tokens: every other byte could start a token. */
 	maxraw = (len / 2) + 1;
 	raw = (RawTerm *) palloc(maxraw * sizeof(RawTerm));
+
+	/*
+	 * Fold the whole input once up front.  ASCII case-folding preserves byte
+	 * length, so each token's text is simply a slice of foldbuf; this avoids a
+	 * per-token palloc.  Token boundaries are unaffected by folding (A-Z and
+	 * a-z are both token bytes), so they are detected on the raw input.
+	 */
+	foldbuf = (char *) palloc(len);
+	for (i = 0; i < len; i++)
+		foldbuf[i] = fold_ascii((unsigned char) str[i]);
 
 	/* First pass: carve out folded tokens. */
 	i = 0;
 	while (i < len)
 	{
 		int			start;
-		char	   *folded;
-		int			flen;
-		int			j;
 
 		/* skip separators */
 		while (i < len && !is_token_byte((unsigned char) str[i]))
@@ -118,15 +126,10 @@ fts_analyze_text(const char *str, int len)
 		start = i;
 		while (i < len && is_token_byte((unsigned char) str[i]))
 			i++;
-		flen = i - start;
-
-		folded = (char *) palloc(flen);
-		for (j = 0; j < flen; j++)
-			folded[j] = fold_ascii((unsigned char) str[start + j]);
 
 		Assert(nraw < maxraw);
-		raw[nraw].term = folded;
-		raw[nraw].len = flen;
+		raw[nraw].term = foldbuf + start;
+		raw[nraw].len = i - start;
 		raw[nraw].pos = doclen + 1;	/* 1-based token position */
 		nraw++;
 		doclen++;

--- a/contrib/pg_fts/pg_fts_doc.c
+++ b/contrib/pg_fts/pg_fts_doc.c
@@ -22,9 +22,12 @@
 #include "postgres.h"
 
 #include "pg_fts.h"
+#include "catalog/pg_collation.h"
 #include "lib/stringinfo.h"
 #include "libpq/pqformat.h"
+#include "regex/regex.h"
 #include "utils/builtins.h"
+#include "utils/varlena.h"
 
 PG_FUNCTION_INFO_V1(ftsdoc_in);
 PG_FUNCTION_INFO_V1(ftsdoc_out);
@@ -289,10 +292,6 @@ fts_doc_has_prefix(FtsDoc doc, const char *prefix, int prefixlen)
 	}
 	return false;
 }
-
-#include "catalog/pg_collation.h"
-#include "regex/regex.h"
-#include "utils/varlena.h"
 
 /*
  * fts_doc_has_fuzzy -- does any doc term lie within edit distance k of `term`?

--- a/contrib/pg_fts/pg_fts_doc.c
+++ b/contrib/pg_fts/pg_fts_doc.c
@@ -48,13 +48,25 @@ append_quoted_term(StringInfo buf, const char *term, int len)
 {
 	int			i;
 
+	/*
+	 * Terms are printed single-quoted, so a literal quote or backslash inside a
+	 * term would otherwise be ambiguous.  Escape both by doubling them ('' and
+	 * \\), matching tsvector's output convention (tsvectorout) rather than
+	 * inventing a second one.
+	 *
+	 * In practice this branch is never taken for terms produced by the analyzer:
+	 * is_token_byte() classifies the ASCII bytes '\'' (0x27) and '\\' (0x5C) as
+	 * separators, so they cannot appear inside a tokenized term.  The escaping
+	 * only matters for terms carried in by ftsdoc_recv(), which accepts
+	 * arbitrary bytes off the wire; it is kept for correctness on that path.
+	 */
 	appendStringInfoChar(buf, '\'');
 	for (i = 0; i < len; i++)
 	{
 		char		c = term[i];
 
 		if (c == '\'' || c == '\\')
-			appendStringInfoChar(buf, '\\');
+			appendStringInfoChar(buf, c);	/* double it: '' or \\ */
 		appendStringInfoChar(buf, c);
 	}
 	appendStringInfoChar(buf, '\'');


### PR DESCRIPTION
Three small, independent cleanups to `contrib/pg_fts` found while reading through the extension. Each is a separate commit and can be taken or dropped on its own.

### 1. Fold analyzer tokens once instead of per-token `palloc`
`fts_analyze_text()` allocated a fresh buffer for every token just to hold its case-folded text. Since ASCII case-folding preserves byte length, the whole input is now folded once into a single buffer and each `RawTerm` points at a slice of it — removing one `palloc` per token on the indexing hot path. Output is byte-identical.

### 2. Escape quote/backslash in `ftsdoc_out` like `tsvector`
`append_quoted_term()` backslash-escaped an embedded single quote (`\'`). It now doubles both the quote (`''`) and the backslash (`\\`), matching `tsvectorout`'s convention rather than introducing a second escaping style. A comment notes that analyzer-produced terms can never contain these bytes (`is_token_byte` treats `0x27`/`0x5C` as separators), so the branch only applies to terms carried in via `ftsdoc_recv()`.

_Note:_ `ftsdoc_in()` does not yet parse this text representation back, so `out`/`in` is not a faithful round-trip. That's a larger item and is intentionally left out of this PR.

### 3. Move `pg_fts_doc.c` includes to the top of the file
`catalog/pg_collation.h`, `regex/regex.h`, and `utils/varlena.h` were included mid-file, next to the fuzzy/regex helpers that use them. They're moved into the top include block (postgres.h first, then module + system headers alphabetically) to match PostgreSQL's source convention. No functional change.

### Testing
Built with `-Dcassert=true -Ddebug=true` on macOS/arm64 (PG 20devel, clang 21). Zero new warnings. Full `pg_fts` suite passes: `regress`, `isolation` (bm25_cic, bm25_concurrency), `001_crash_recovery`, `002_replication`. The escaping change was additionally exercised by loading a hand-crafted binary `ftsdoc` (term `a'b\c`) via `COPY … FORMAT binary` through `ftsdoc_recv`, confirming output `'a''b\\c':1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
